### PR TITLE
Removing avaliation from delivery not biddings

### DIFF
--- a/App/Controllers/SolicitacaoController.php
+++ b/App/Controllers/SolicitacaoController.php
@@ -251,8 +251,9 @@ class SolicitacaoController extends Controller implements CtrlInterface
         $resultSolicitacao = $solicitacao->findById($this->getParametro('id'));
         if ($resultSolicitacao['nao_licitado'] == 1) {
             $solicitacao->recbimentoNaoLicitado($this->getParametro('id'), $resultSolicitacao['id_lista']);
+        } else {
+            $solicitacao->recebimento($this->getParametro('id'), $this->view->userLoggedIn);
         }
-        $solicitacao->recebimento($this->getParametro('id'), $this->view->userLoggedIn);
     }
 
     public function processarAction()

--- a/App/Models/SolicitacaoModel.php
+++ b/App/Models/SolicitacaoModel.php
@@ -216,6 +216,8 @@ class SolicitacaoModel extends CRUD
             . 'ocultar("btn_enviar");'
             . 'ocultar("numero_nota_fiscal_container");'
             . 'ocultar("observacao");'
+            . 'ocultar("nota");'
+            . 'ocultar("legenda");'
             . '</script>', 'success');
     }
 
@@ -280,7 +282,8 @@ class SolicitacaoModel extends CRUD
         $this->navPaginator = $paginator->getNaveBtn();
     }
 
-    public function paginatorSolicitacoes($pagina, $user, $busca = null, $omId = null, $dtInicio = null, $dtFim = null) {
+    public function paginatorSolicitacoes($pagina, $user, $busca = null, $omId = null, $dtInicio = null, $dtFim = null)
+    {
         $innerJoin = ""
             . " as sol INNER JOIN om ON om.id = sol.om_id ";
 
@@ -299,7 +302,7 @@ class SolicitacaoModel extends CRUD
 
         if ($busca || $dtInicio || $dtFim) {
 
-            if(preg_match('/\d{2}-\d{2}-\d{4}/', $dtInicio)) {
+            if (preg_match('/\d{2}-\d{2}-\d{4}/', $dtInicio)) {
                 $exDate = explode('-', $dtInicio);
                 $exDate = array_reverse($exDate);
                 $exDate = implode('-', $exDate);
@@ -309,7 +312,7 @@ class SolicitacaoModel extends CRUD
                 $dateInit = $date->getTimestamp();
             }
 
-            if(preg_match('/\d{2}-\d{2}-\d{4}/', $dtFim)) {
+            if (preg_match('/\d{2}-\d{2}-\d{4}/', $dtFim)) {
                 $exDate = explode('-', $dtFim);
                 $exDate = array_reverse($exDate);
                 $exDate = implode('-', $exDate);

--- a/App/Views/Solicitacao/index.phtml
+++ b/App/Views/Solicitacao/index.phtml
@@ -9,10 +9,9 @@ $userNivel = $this->view->userLoggedIn['nivel'];
  * @param string $action The action to be executed
  * @return string The build string
  */
-$buildUrlBtnAction = function (array $value, string $action = 'proximo'): string
-{
+$buildUrlBtnAction = function (array $value, string $action = 'proximo'): string {
     if (
-        isset($value['status'], $value['nao_licitado']) && 
+        isset($value['status'], $value['nao_licitado']) &&
         $value['status'] === 'APROVADO' &&
         $value['nao_licitado'] === '1' &&
         $action !== 'anterior'
@@ -162,8 +161,8 @@ $buildUrlBtnAction = function (array $value, string $action = 'proximo'): string
                                     <?php endif; ?>
                                     <?php if ($userNivel != 'CONTROLADOR' && $value['status'] == 'ABERTO'): ?>
                                         <a
-                                           onclick="confirmar('Deseja REMOVER este registro?', '<?= $this->view->controller; ?>eliminar/id/<?= $value['id_lista']; ?>')"
-                                           class="btn btn-danger btn-sm">
+                                            onclick="confirmar('Deseja REMOVER este registro?', '<?= $this->view->controller; ?>eliminar/id/<?= $value['id_lista']; ?>')"
+                                            class="btn btn-danger btn-sm">
                                             <i class="fa fa-trash"></i>
                                         </a>
                                     <?php endif; ?>
@@ -210,9 +209,15 @@ $buildUrlBtnAction = function (array $value, string $action = 'proximo'): string
                     </ul>
                 </nav>
             </div>
-            <!-- /.col-lg-12 -->
         </div>
-        <!-- /.row -->
     </div>
-    <!-- /.container-fluid -->
 </div>
+<script>
+    $('.search-button').click(function btnSearch() {
+        var searchValue = $('.search-input').val();
+        var formAction = $('.search-form').attr('action');
+        if (searchValue && formAction) {
+            window.location = formAction + '/busca/' + searchValue;
+        }
+    });
+</script>

--- a/App/Views/Solicitacao/mostra_item_recebimento.phtml
+++ b/App/Views/Solicitacao/mostra_item_recebimento.phtml
@@ -11,7 +11,7 @@
                         <input type="hidden" name="nao_licitado" value="<?= $this->view->result[0]['nao_licitado'] ?>">
                         <input type="hidden" name="data_entrega" value="<?= date("d-m-Y", time()); ?>">
                         <button class="btn btn-success" id='btn_enviar'>
-                            <i class="fa fa-check"></i> Confirmar Registro
+                            <i class="fa fa-check"></i> Confirmar Recebimento
                         </button>
                         <div class="row" style="padding-top: 10px;">
                             <div class="col-lg-4" id="numero_nota_fiscal_container">
@@ -23,42 +23,46 @@
                                        placeholder="Número da nota fiscal"
                                        autofocus>
                             </div>
-                            <div class="col-lg-4" id="nota">
-                                <label>Avaliação da entrega: </label><br>
-                                <input type="radio" name="nota" value="1">
-                                <span class="label label-danger">
-                                    1
-                                </span>&nbsp;
-                                <input type="radio" name="nota" value="2">
-                                <span class="label label-default">
-                                    2
-                                </span>&nbsp;
-                                <input type="radio" name="nota" value="3" checked>
-                                <span class="label label-warning">
-                                    3
-                                </span>&nbsp;
-                                <input type="radio" name="nota" value="4">
-                                <span class="label label-success">
-                                    4
-                                </span>&nbsp;
-                                <input type="radio" name="nota" value="5">
-                                <span class="label label-info">
-                                    5
-                                </span>
-                            </div>
+                            <?php if (isset($this->view->result[0]['nao_licitado']) && $this->view->result[0]['nao_licitado'] !== '1'): ?>
+                                <div class="col-lg-4" id="nota">
+                                    <label>Avaliação da entrega: </label><br>
+                                    <input type="radio" name="nota" value="1">
+                                    <span class="label label-danger">
+                                        1
+                                    </span>&nbsp;
+                                    <input type="radio" name="nota" value="2">
+                                    <span class="label label-default">
+                                        2
+                                    </span>&nbsp;
+                                    <input type="radio" name="nota" value="3" checked>
+                                    <span class="label label-warning">
+                                        3
+                                    </span>&nbsp;
+                                    <input type="radio" name="nota" value="4">
+                                    <span class="label label-success">
+                                        4
+                                    </span>&nbsp;
+                                    <input type="radio" name="nota" value="5">
+                                    <span class="label label-info">
+                                        5
+                                    </span>
+                                </div>
+                            <?php endif; ?>
                         </div>
-                        <div class="row" style="padding-top: 10px;">
+                        <div class="row" style="padding-top: 10px; margin-bottom: 20px;">
                             <div class="col-lg-4" id="observacao">
                                 <label>Observação: </label>
                                 <textarea name="observacao"
                                           placeholder="Observações"
                                           class="form-control"></textarea>
                             </div>
+                            <?php if (isset($this->view->result[0]['nao_licitado']) && $this->view->result[0]['nao_licitado'] !== '1'): ?>
                             <div class="col-lg-6" id="legenda">
                                 <label>Legenda:</label><br>
                                 <span class="label label-danger" style="font-size: 14px !important;">1 - Muito insatisfeito</span> à
                                 <span class="label label-info" style="font-size: 14px !important;">5 - Muito satisfeito</span>
                             </div>
+                            <?php endif; ?>
                         </div>
                         <table class="table" id='tabela_result'>
                             <thead>

--- a/public/js/sb-admin-2.js
+++ b/public/js/sb-admin-2.js
@@ -34,11 +34,3 @@ $(function() {
         element.addClass('active');
     }
 });
-
-$('.search-button').click(function() {
-    var searchValue = $('.search-input').val();
-    var formAction = $('.search-form').attr('action');
-    if (searchValue && formAction) {
-        window.location = formAction + '/busca/' + searchValue;
-    }
-});

--- a/vendor/HTR/Helpers/Paginator/Paginator.php
+++ b/vendor/HTR/Helpers/Paginator/Paginator.php
@@ -138,11 +138,6 @@ class Paginator extends CRUD
         return $this;
     }
 
-    private function getTotalPagina()
-    {
-        return $this->totalPagina;
-    }
-
     private function setMaxOffSet()
     {
         $page = $this->getPagina();
@@ -275,8 +270,9 @@ class Paginator extends CRUD
             echo '<style>.pagination{display:none !important;}</style>';
             return [
                 'link' => [],
-                'previous' => '#',
-                'next' => '#'
+                'previous' => 1,
+                'next' => 1,
+                'current' => 1,
             ];
         }
         return $this->btn = $this->makeBtn();


### PR DESCRIPTION
#### Entregas de Não Licitado não deve ter avaliação

[https://trello.com/c/1Ir8AHbk](https://trello.com/c/1Ir8AHbk)

Members: [Edson Monteiro](https://trello.com/edsonbsmonteiro), [Paulo Henrique Coelho Gaia](https://trello.com/paulohenriquecoelhogaia), [Kedyson Ferreira](https://trello.com/kedysonferreira)


##### Problem
Ao receber os produtos de uma solicitação, o usuário deve também avaliar a entrega que o fornecedor realizou. Esta avaliação não deve ser aplicada para solicitações de Não Licitados

##### Solution
A não avaliação de entrega para não licitados já estava ocorrendo, mas ainda assim nós exibíamos os campos usados para dar nota ao recebimento. Os campos de `Nº da Nota Fiscal` e `Observação` fazem parte da solicitação e não da avaliação, por isso ainda continuam presentes na página. Além disso, foram ajustados alguns pontos para melhorar o código.

>Movida a função de ação do botão de buscar para dentro da view `index.phtml` de `Solicitacao`

>Fixado o problema do index `current` no paginador quando não há resultados retornados na consulta