### PR TITLE
Ação do botão "Processar"

### DIFF
--- a/App/Controllers/SolicitacaoController.php
+++ b/App/Controllers/SolicitacaoController.php
@@ -280,13 +280,13 @@ class SolicitacaoController extends Controller implements CtrlInterface
 
         (new SolicitacaoModel())->processStatus($id, $status, $action);
 
-        header('location: ' . $this->view->controller);
-
-        if($status == 'APROVADO' && $action == 'PROXIMO') {
+        if ($status == 'APROVADO' && $action == 'PROXIMO') {
             $solicitacao = (new SolicitacaoModel())->findById($id);
             header('location: '
                 . $this->view->controller
-                . 'detalhar/idlista/'.$solicitacao['id_lista']);
+                . 'detalhar/idlista/' . $solicitacao['id_lista']);
+        } else {
+            header('location: ' . $this->view->controller);
         }
     }
 

--- a/App/Controllers/SolicitacaoController.php
+++ b/App/Controllers/SolicitacaoController.php
@@ -281,6 +281,13 @@ class SolicitacaoController extends Controller implements CtrlInterface
         (new SolicitacaoModel())->processStatus($id, $status, $action);
 
         header('location: ' . $this->view->controller);
+
+        if($status == 'APROVADO' && $action == 'PROXIMO') {
+            $solicitacao = (new SolicitacaoModel())->findById($id);
+            header('location: '
+                . $this->view->controller
+                . 'detalhar/idlista/'.$solicitacao['id_lista']);
+        }
     }
 
     public function processarnaolicitadoAction()


### PR DESCRIPTION
**Ação do botão "Processar" para Solicitações de Licitados**

**Problem**
Este botão deve ter a ação de alterar o status de "APROVADO" para "PROCESSADO", porém,após realizar esta ação o usuário deve ser levado para tela de itens da Solicitação e não mais para tela de Histórico de Solicitações.
Exemplo de página de itens da solicitação (Mesmo link do botão Itens na página de Histórico de Solicitações)

**Solution**
Foi adicionado uma verificação no controller de solicitacao para verificar o status e a ação do usuário, caso o usuário esteja com a ação `PROXIMO` e o status `APROVADO` , o controller irá direcionar o usuário para a página de item conforme especificação da tarefa.