### PR TITLE
Separating the search page

### DIFF
--- a/App/Controllers/SolicitacaoController.php
+++ b/App/Controllers/SolicitacaoController.php
@@ -114,14 +114,20 @@ class SolicitacaoController extends Controller implements CtrlInterface
 
     public function itensLicitadosAction()
     {
-        $this->view->userLoggedIn = $this->access->setRedirect('solicitacao/')
-            ->clearAccessList()
-            ->authenticAccess(['ADMINISTRADOR', 'CONTROLADOR', 'ENCARREGADO', 'NORMAL']);
+        $this->view->busca = $this->getParametro('busca');
 
-        $licitacao = new Licitacao();
-        $this->view->title = 'Forncedores e itens encontrados';
-        $this->view->result = $licitacao->listaItemFornecedor($this->getParametro('busca'));
-        $this->render('mostra_item_buscado');
+        if ($this->view->busca) {
+            $this->view->userLoggedIn = $this->access->setRedirect('solicitacao/')
+                ->clearAccessList()
+                ->authenticAccess(['ADMINISTRADOR', 'CONTROLADOR', 'ENCARREGADO', 'NORMAL']);
+
+            $licitacao = new Licitacao();
+            $this->view->title = 'Forncedores e itens encontrados';
+            $this->view->result = $licitacao->listaItemFornecedor($this->getParametro('busca'));
+            $this->render('mostra_item_buscado');
+        } else {
+            $this->licitacaobuscaAction();
+        }
     }
 
     public function eliminarAction()
@@ -349,5 +355,15 @@ class SolicitacaoController extends Controller implements CtrlInterface
         if ($numero !== 'error') {
             $solicitacaoModel->saveOneFile(getcwd(), $numero);
         }
+    }
+
+    public function licitacaobuscaAction()
+    {
+        $this->view->userLoggedIn = $this->access->setRedirect('solicitacao/')
+            ->clearAccessList()
+            ->authenticAccess(['ADMINISTRADOR', 'CONTROLADOR', 'NORMAL']);
+
+        $this->view->title = 'Busca de itens licitados';
+        $this->render('mostra_busca_fornecedor');
     }
 }

--- a/App/Views/Layout/menu_vertical.phtml
+++ b/App/Views/Layout/menu_vertical.phtml
@@ -51,7 +51,10 @@
                     <i class="fa fa-history"></i> Histórico
                 </a>
                 <a class="collapse-item" href="solicitacao/licitacao/">
-                    <i class="fa fa-group"></i> Licitado
+                    <i class="fa fa-group"></i> Licitado - PE/Empresa
+                </a>
+                <a class="collapse-item" href="solicitacao/licitacaobusca/">
+                    <i class="fa fa-group"></i> Licitado - Item
                 </a>
                 <a class="collapse-item" href="solicitacao/formnaolicitado/">
                     <i class="fa fa-shopping-cart"></i> Não Licitado
@@ -59,6 +62,30 @@
             </div>
         </div>
     </li>
+
+    <?php if (in_array($this->view->userLoggedIn['nivel'], ['ADMINISTRADOR', 'CONTROLADOR']) === false) : ?>
+        <li class="nav-item">
+            <a class="nav-link collapsed"
+               href="#"
+               data-toggle="collapse"
+               data-target="#menuFornecedor"
+               aria-expanded="true"
+               aria-controls="menuFornecedor">
+                <i class="fa fa-suitcase fa-fw"></i> Fornecedor
+                <span class="fa arrow"></span>
+            </a>
+            <div id="menuFornecedor"
+                 class="collapse"
+                 aria-labelledby="headingUtilities"
+                 data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item" href="fornecedor/novo/">
+                        <i class="fa fa-plus-circle"></i> Novo Registro
+                    </a>
+                </div>
+            </div>
+        </li>
+    <?php endif; ?>
 
     <?php if (in_array($this->view->userLoggedIn['nivel'], ['ADMINISTRADOR', 'CONTROLADOR'])) : ?>
         <li class="nav-item">

--- a/App/Views/Solicitacao/mostra_busca_fornecedor.phtml
+++ b/App/Views/Solicitacao/mostra_busca_fornecedor.phtml
@@ -1,0 +1,57 @@
+<div id="page-wrapper">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12 search-container">
+                <div class="row">
+                    <div class="col-lg-2"></div>
+                    <div class="col-lg-8">
+                        Use essas dicas para melhorar seu resultado de busca:<br>
+                        <ul class="text-info">
+                            <li>Procure sempre usar termos simples. Por exemplo: arroz, leite.</li>
+                            <li>Sempre que possível, evite caracteres especiais</li>
+                            <li>Nunca use o caractere <b>/ (barra)</b> em suas buscas</li>
+                            <li>Esta ferramenta buscará apenas nos <b>nomes</b> de itens cadastrados, e só exibirá itens de Licitações vigentes</li>
+                        </ul>
+                    </div>
+                    <div class="col-lg-2"></div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-2"></div>
+                    <div class="col-lg-8">
+                        <form
+                            action="<?= $this->view->controller; ?>itensLicitados"
+                            class="search-form"
+                            onsubmit="return false">
+                            <div class="input-group search-input-box">
+                                <input type="text" class="form-control search-input" placeholder="Buscar itens licitados...">
+                                <span class="input-group-btn">
+                                    <button class="btn btn-secondary search-button" type="button">
+                                        <i class="fa fa-search"></i>
+                                    </button>
+                                </span>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="col-lg-2"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    $('.search-button').click(function btnSearch() {
+        var searchInput = $('.search-input');
+        var searchValue = searchInput.val();
+        var formAction = $('.search-form').attr('action');
+        if (searchValue && formAction) {
+            window.location = formAction + '/busca/' + searchValue;
+        } else {
+            searchInput.focus();
+        }
+    });
+</script>
+<style>
+    .search-container {
+        margin-top: 100px;
+    }
+</style>

--- a/App/Views/Solicitacao/mostra_item_buscado.phtml
+++ b/App/Views/Solicitacao/mostra_item_buscado.phtml
@@ -1,16 +1,58 @@
 <?php
+
 use App\Helpers\View;
-$busca = $this->getParametro('busca');
+
 ?>
 <div id="page-wrapper">
     <div class="container-fluid">
         <div class="row">
             <div class="col-lg-12">
                 <?php if ($this->view->result) { ?>
-                <i class="fa fa-list"></i> <?= $this->view->title; ?><br>
-                <div class="row">
-                    <div class="col-md-7"></div>
-                    <div class="col-lg-5">
+                    <i class="fa fa-list"></i> <?= $this->view->title; ?><br>
+                    <div class="row">
+                        <div class="col-md-7"></div>
+                        <div class="col-lg-5">
+                            <form
+                                action="<?= $this->view->controller; ?>itensLicitados"
+                                class="search-form"
+                                onsubmit="return false">
+                                <div class="input-group search-input-box">
+                                    <input type="text" class="form-control search-input" placeholder="Buscar itens licitados...">
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-secondary search-button" type="button">
+                                            <i class="fa fa-search"></i>
+                                        </button>
+                                    </span>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                    <table class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>Licitação</th>
+                                <th>Fornecedor</th>
+                                <th width="45%">Item</th>
+                                <th width="15%"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($this->view->result as $value): ?>
+                                <tr>
+                                    <td><?= $value['numero']; ?></td>
+                                    <td><?= $value['nome']; ?></td>
+                                    <td><?= View::highlight(strtoupper($value['produtoNome']), strtoupper($this->view->busca)) ?></td>
+                                    <td>
+                                        <a href="<?= $this->view->controller; ?>item/fornecedor/<?= $value['fornecedor_id']; ?>/idlista/<?= $value['id_lista']; ?>" class="btn btn-success btn-sm">
+                                            <i class="fa fa-edit"></i> Ir para Fornecedor
+                                        </a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php } else { ?>
+                    <div class="col-lg-12">
                         <form
                             action="<?= $this->view->controller; ?>itensLicitados"
                             class="search-form"
@@ -25,52 +67,11 @@ $busca = $this->getParametro('busca');
                             </div>
                         </form>
                     </div>
-                </div>
-                <table class="table table-striped table-hover">
-                    <thead>
-                        <tr>
-                            <th>Licitação</th>
-                            <th>Fornecedor</th>
-                            <th width="45%">Item</th>
-                            <th width="15%"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($this->view->result as $value): ?>
-                            <tr>
-                                <td><?= $value['numero']; ?></td>
-                                <td><?= $value['nome']; ?></td>
-                                <td><?= View::highlight(strtoupper($value['produtoNome']), strtoupper($busca)) ?></td>
-                                <td>
-                                    <a href="<?= $this->view->controller; ?>item/fornecedor/<?= $value['fornecedor_id']; ?>/idlista/<?= $value['id_lista']; ?>" class="btn btn-success btn-sm">
-                                        <i class="fa fa-edit"></i> Ir para Fornecedor
-                                    </a>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-                <?php } else { ?>
-                <div class="col-lg-12">
-                    <form
-                        action="<?= $this->view->controller; ?>itensLicitados"
-                        class="search-form"
-                        onsubmit="return false">
-                        <div class="input-group search-input-box">
-                            <input type="text" class="form-control search-input" placeholder="Buscar produtos licitados...">
-                            <span class="input-group-btn">
-                                <button class="btn btn-secondary search-button" type="button">
-                                    <i class="fa fa-search"></i>
-                                </button>
-                            </span>
-                        </div>
-                    </form>
-                </div>
-                <br>
-                <div class="alert alert-warning">
-                    <i class="fa fa-warning"></i> Nenhum resultado encontrado para <b><?= $busca ?></b>. Tente outra busca! <br />
-                    <br/>
-                </div>
+                    <br>
+                    <div class="alert alert-warning">
+                        <i class="fa fa-warning"></i> Nenhum resultado encontrado para <b><?= $this->view->busca ?></b>. Tente outra busca! <br />
+                        <br/>
+                    </div>
                 <?php } ?>
             </div>
         </div>

--- a/App/Views/Solicitacao/mostra_licitacao_disponivel.phtml
+++ b/App/Views/Solicitacao/mostra_licitacao_disponivel.phtml
@@ -22,25 +22,9 @@ $pagination = Pagination::make($this, function ($btn, $controllerName) {
                     <div class="col-md-7">
                         <?= $pagination; ?>
                     </div>
-
-                    <div class="col-lg-5">
-                        <form
-                            action="<?= $this->view->controller; ?>itensLicitados"
-                            class="search-form"
-                            onsubmit="return false">
-                            <div class="input-group search-input-box">
-                                <input type="text" class="form-control search-input" placeholder="Buscar produtos licitados...">
-                                <span class="input-group-btn">
-                                    <button class="btn btn-secondary search-button" type="button">
-                                        <i class="fa fa-search"></i>
-                                    </button>
-                                </span>
-                            </div>
-                        </form>
-                    </div>
                 </div>
 
-                <table class="table">
+                <table class="table table-hover">
                     <thead>
                         <tr>
                             <th>Numero</th>
@@ -48,12 +32,11 @@ $pagination = Pagination::make($this, function ($btn, $controllerName) {
                             <th>UASG</th>
                             <th>Órgão</th>
                             <th>Validade</th>
-                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($this->view->result as $value): ?>
-                            <tr class="table-licitacao" data-idLista="<?= $value['id_lista']; ?>">
+                            <tr class="table-licitacao" data-id-lista="<?= $value['id_lista']; ?>">
                                 <td><?= $value['numero']; ?></td>
                                 <td><?= $value['descricao']; ?></td>
                                 <td><?= $value['uasg']; ?></td>
@@ -73,24 +56,15 @@ $pagination = Pagination::make($this, function ($btn, $controllerName) {
     </div>
 </div>
 <script>
-    $('.search-button').click(function btnSearch() {
-        var searchInput = $('.search-input');
-        var searchValue = searchInput.val();
-        var formAction = $('.search-form').attr('action');
-        if (searchValue && formAction) {
-            window.location = formAction + '/busca/' + searchValue;
-        } else {
-            searchInput.focus();
-        }
-    });
     $('.table-licitacao').click(function link() {
-        var idLista = $(this).attr('data-idLista');
-        window.location = "<?= $this->view->controller; ?>fornecedor/idlista/"+idLista;
+        var idLista = this.dataset.idLista;
+        if (idLista) {
+            window.location = '<?= $this->view->controller; ?>fornecedor/idlista/' + idLista;
+        }
     });
 </script>
 <style>
     .table-licitacao:hover {
         cursor: pointer;
-        background-color: #ccc;
     }
 </style>


### PR DESCRIPTION
https://app.asana.com/0/1109719096158391/1109991186382624

#### problem
Será necessário alterar o nome do link "Licitado" pata "Licitado - PE/Empresa". Além disso será necessário adicionar um novo link com "Licitado - Item". Os comportamentos esperados por cada link desses é:
"Licitado - PE/Empresa": Deve levar para página normal lista de Licitações (http://www.ceimbe.mb/app/sisgeneros/solicitacao/licitacao/). Este comportamento já ocorre atualmente, porém nesta página não poderá ter o campo de busca.

"Licitado - Item": Deve levar para uma página onde tenha apenas o campo de busca. (Busca por item do comportamento atual). Acima do campo de busca deve conter informações para auxiliar o usuário na busca, algo como "Evite frases muito grandes na busca. Evite caracteres especiais como '/' e etc."

#### solution
Foi realizada a separação das páginas de busca  de itens licitados e da listagem de licitações disponíveis. Além disso, foi refatorado alguns pontos de melhoria nas páginas.