### PR TITLE
Fix pagination

### DIFF
--- a/App/Views/Solicitacao/index.phtml
+++ b/App/Views/Solicitacao/index.phtml
@@ -31,9 +31,9 @@ $buildUrlBtnAction = function (array $value, string $action = 'proximo'): string
 
 $pagination = Pagination::make($this, function ($btn, $controllerName) use ($busca) {
         return [
-            'previous' => "{$controllerName}solicitacao/pagina/{$btn['previous']}" . $busca,
-            'next' => "{$controllerName}solicitacao/pagina/{$btn['next']}" . $busca,
-            'current' => "{$controllerName}solicitacao/pagina/" . Pagination::CURRENT_PAGE . $busca
+            'previous' => "{$controllerName}ver/pagina/{$btn['previous']}" . $busca,
+            'next' => "{$controllerName}ver/pagina/{$btn['next']}" . $busca,
+            'current' => "{$controllerName}ver/pagina/" . Pagination::CURRENT_PAGE . $busca
         ];
     });
 


### PR DESCRIPTION
#### problem
sempre que há itens suficientes para paginação, os links da paginação quebravam.

#### solution
este problema estava ocorrendo devido o nome do controller está sendo passado no lugar da action. Para resolver, apenas mudei para o nome correto.